### PR TITLE
fix link to wiki page

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -4,7 +4,7 @@ für Magnus bzw. Simon, um Commits/PullRequests für lernOS bereizustellen.
 
 und alle anderen ;-)
 
-Hier geht's zum [Wiki](wiki).
+Hier geht's zum [Wiki](https://github.com/lootsy/GithubTutorial-TestRepo/wiki).
 
 ## Schritte
 


### PR DESCRIPTION
Tja, was soll ich sagen...

So einfach ging das dann doch nicht.
Da stand ein "blob/develop" dem "wiki" noch entgegen.

Wie github intern verlinkt, muss ich wohl noch lernen.